### PR TITLE
feat: tool-agnostic interface

### DIFF
--- a/kombuworker/agnostic.py
+++ b/kombuworker/agnostic.py
@@ -1,0 +1,131 @@
+"""Task interface where user packages define how to parse tasks."""
+import sys
+import json
+import time
+import signal
+from types import SimpleNamespace
+from typing import Optional, Callable
+
+from . import queuetools as qt
+
+
+def parse_queue(
+    queue_url: str, tool_name: str, queue_name: Optional[str] = None
+) -> SimpleNamespace:
+    """Parses queue information into a tool-specific sub-queue."""
+    q = SimpleNamespace()
+
+    if queue_url.startswith("https://"):  # SQS in disguise?
+        queue_url = queue_url.replace("https://", "sqs://")
+
+    q.url = queue_url
+    q.name = tool_name if queue_name is None else f"{queue_name}::{tool_name}"
+
+    return q
+
+
+def insert_task(
+    queue_url: str, tool_name: str, *args: list, queue_name: str = None, **kwargs: dict,
+) -> None:
+    """Submits a single task to the desired queue."""
+    insert_tasks(queue_url, tool_name, [args], [kwargs], queue_name=queue_name)
+
+
+def insert_tasks(
+    queue_url: str,
+    tool_name: str,
+    task_args: list[list],
+    task_kwargs: list[dict],
+    queue_name: str = None,
+) -> None:
+    """Submits a set of tasks to the desired queue.
+
+    Lengths of task_args and task_kwargs must match.
+    """
+    assert len(task_args) == len(task_kwargs), "mismatched task_args & task_kwargs"
+
+    q = parse_queue(queue_url, tool_name, queue_name)
+
+    packed = [
+        json.dumps(dict(args=args, kwargs=kwargs))
+        for (args, kwargs) in zip(task_args, task_kwargs)
+    ]
+
+    qt.insert_msgs(q.url, q.name, packed)
+
+
+def poll(
+    queue_url: str,
+    tool_name: str,
+    task_parser: Callable,
+    queue_name: Optional[str] = None,
+    init_waiting_period: Optional[int] = 1,
+    max_waiting_period: Optional[int] = 60,
+    max_num_retries: Optional[int] = 5,
+    verbose: Optional[bool] = False,
+) -> None:
+    """Fetches tasks and executes them.
+
+    Fetches messages from the queue. Parses them using the (tool-defined) parser
+    to create tasks, and executes those tasks.
+    """
+    q = parse_queue(queue_url, tool_name, queue_name)
+
+    global KEEP_LOOPING
+    KEEP_LOOPING = True
+
+    def siginthandler(signum, frame):
+        global KEEP_LOOPING
+        if KEEP_LOOPING:
+            print(
+                "Interrupted w/ SIGINT."
+                " Exiting after this task completes."
+                " Interrupt again to exit now.",
+                flush=True,
+            )
+            KEEP_LOOPING = False
+        else:
+            sys.exit()
+
+    def sigtermhandler(signum, frame):
+        print("Interrupted w/ SIGTERM. Exiting now.", flush=True)
+        sys.exit()
+
+    prev_siginthandler = signal.getsignal(signal.SIGINT)
+    signal.signal(signal.SIGINT, siginthandler)
+
+    prev_sigtermhandler = signal.getsignal(signal.SIGTERM)
+    signal.signal(signal.SIGTERM, sigtermhandler)
+
+    it = qt.fetch_msgs(
+        q.url,
+        q.name,
+        init_waiting_period=init_waiting_period,
+        max_waiting_period=max_waiting_period,
+        max_num_retries=max_num_retries,
+        verbose=verbose,
+    )
+
+    while KEEP_LOOPING:
+        try:
+            msg = next(it)
+            parsed = json.loads(msg.payload)
+            args, kwargs = parsed["args"], parsed["kwargs"]
+
+            task = task_parser(*args, **kwargs)
+
+            start_time = time.time()
+            task()
+            elapsed = time.time() - start_time
+
+            qt.ack_msg(msg)
+            print(f"Task successfully executed in {elapsed:.2f}s")
+
+        except StopIteration:
+            break
+
+    # Cleaning up in case fetch_msgs stops naturally
+    signal.signal(signal.SIGINT, prev_siginthandler)
+    signal.signal(signal.SIGTERM, prev_sigtermhandler)
+
+    it.close()

--- a/test/test_agnostic.py
+++ b/test/test_agnostic.py
@@ -1,0 +1,78 @@
+"""Tests for kombuworker/taskqueueworker.py"""
+import os
+
+from kombuworker import agnostic as ag
+import utils
+
+
+DUMMYDIR = "test/dummy_files"
+
+
+def dummy_side_effect(i):
+    os.makedirs(DUMMYDIR, exist_ok=True)
+    with open(os.path.join(DUMMYDIR, str(i)), "w+") as f:
+        f.write(str(i))
+
+
+def test_parse_queue():
+    assert ag.parse_queue("sqs://fake_queue", "test").url.startswith("sqs")
+    assert ag.parse_queue("https://fake_queue", "test").url.startswith("sqs")
+    assert ag.parse_queue("amqp://fake_queue", "test").url.startswith("amqp")
+    assert ag.parse_queue("sqs://fake_queue", "test", "name").name == "name::test"
+    assert ag.parse_queue("sqs://fake_queue", "test").name == "test"
+
+
+def test_insert_tasks(rabbitMQurl):
+    tool_name = "pytest"
+    queue_name = "agnostic"
+    q = ag.parse_queue(rabbitMQurl, tool_name, queue_name)
+
+    utils.clear_queue(q.url, q.name)
+
+    ag.insert_task(rabbitMQurl, tool_name, "a", b=1, queue_name=queue_name)
+    assert utils.count_msgs(q.url, q.name) == 1
+
+    task_args = [["a1"], ["a2"]]
+    task_kwargs = [{"b1": 1}, {"b2": 2}]
+
+    ag.insert_tasks(
+        rabbitMQurl, tool_name, task_args, task_kwargs, queue_name=queue_name
+    )
+
+    assert utils.count_msgs(q.url, q.name) == len(task_args)
+
+
+def test_poll_side_effects(rabbitMQurl):
+    tool_name = "pytest"
+    q = ag.parse_queue(rabbitMQurl, tool_name)
+
+    utils.clear_queue(q.url, q.name)
+
+    ids = range(10)
+    task_args = [[i] for i in ids]
+    task_kwargs = [{} for i in ids]
+    ag.insert_tasks(rabbitMQurl, tool_name, task_args, task_kwargs)
+
+    def task_parser(i: int):
+        """Returns a function that runs the dummy_side_effect above."""
+
+        def fn():
+            dummy_side_effect(i)
+
+        return fn
+
+    ag.poll(
+        rabbitMQurl,
+        tool_name,
+        task_parser,
+        init_waiting_period=0.1,
+        max_waiting_period=1,
+        verbose=True,
+    )
+
+    for i in ids:
+        filename = os.path.join(DUMMYDIR, str(i))
+        assert os.path.exists(filename), f"{filename} doesn't exist"
+        os.remove(filename)
+
+    os.rmdir(DUMMYDIR)


### PR DESCRIPTION
Implementing an interface where tools can define their own `task_parser` function to receive tasks from a producer w/o sharing code. The producer and consumer only need to coordinate on what to call their communication channel (the `tool_name`) and the arguments to the `task_parser` function.