### PR TITLE
Improved Logging + misc changes

### DIFF
--- a/kombuworker/__init__.py
+++ b/kombuworker/__init__.py
@@ -1,0 +1,1 @@
+from . import log

--- a/kombuworker/agnostic.py
+++ b/kombuworker/agnostic.py
@@ -3,10 +3,13 @@ import sys
 import json
 import time
 import signal
+
 from types import SimpleNamespace
-from typing import Optional, Callable
+from typing import Optional, Callable, List
 
 from . import queuetools as qt
+
+from kombuworker.log import logger as kwlogger
 
 
 def parse_queue(
@@ -25,7 +28,11 @@ def parse_queue(
 
 
 def insert_task(
-    queue_url: str, tool_name: str, *args: list, queue_name: str = None, **kwargs: dict,
+    queue_url: str,
+    tool_name: str,
+    *args: list,
+    queue_name: str = None,
+    **kwargs: dict,
 ) -> None:
     """Submits a single task to the desired queue."""
     insert_tasks(queue_url, tool_name, [args], [kwargs], queue_name=queue_name)
@@ -34,8 +41,8 @@ def insert_task(
 def insert_tasks(
     queue_url: str,
     tool_name: str,
-    task_args: list[list],
-    task_kwargs: list[dict],
+    task_args: List[list],
+    task_kwargs: List[dict],
     queue_name: str = None,
 ) -> None:
     """Submits a set of tasks to the desired queue.
@@ -77,18 +84,18 @@ def poll(
     def siginthandler(signum, frame):
         global KEEP_LOOPING
         if KEEP_LOOPING:
-            print(
+            kwlogger.info(
                 "Interrupted w/ SIGINT."
                 " Exiting after this task completes."
                 " Interrupt again to exit now.",
-                flush=True,
             )
             KEEP_LOOPING = False
         else:
             sys.exit()
 
     def sigtermhandler(signum, frame):
-        print("Interrupted w/ SIGTERM. Exiting now.", flush=True)
+
+        kwlogger.info("Interrupted w/ SIGTERM. Exiting now.")
         sys.exit()
 
     prev_siginthandler = signal.getsignal(signal.SIGINT)
@@ -119,7 +126,7 @@ def poll(
             elapsed = time.time() - start_time
 
             qt.ack_msg(msg)
-            print(f"Task successfully executed in {elapsed:.2f}s")
+            kwlogger.info(f"Task successfully executed in {elapsed:.2f}s")
 
         except StopIteration:
             break

--- a/kombuworker/log.py
+++ b/kombuworker/log.py
@@ -1,0 +1,45 @@
+import logging
+import time
+import os
+import pathlib
+
+from datetime import datetime
+from typing import Optional, Callable
+
+
+logger = logging.getLogger("kombuworker")
+
+
+def configure_logger(
+    name: Optional[str] = "kombuworker",
+    verbose: Optional[bool] = True,
+    log_folder: Optional[str] = "/tmp/logs/kombuworker",
+):
+    global logger
+
+    pathlib.Path(log_folder).mkdir(parents=True, exist_ok=True)
+
+    # clear to avoid double add
+    logger.handlers = []
+    log_level = logging.DEBUG if verbose else logging.INFO
+    logger.setLevel(log_level)
+
+    ch = logging.StreamHandler()
+    ch.setLevel(log_level)
+    info_format = "[%(asctime)s.%(msecs)03d, pid%(process)6s, %(filename)20s:%(lineno)4d] %(levelname)6s - %(message)s"
+    time_format = "%m-%d %H:%M:%S"
+    formatter = logging.Formatter(info_format, time_format)
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+    # This ts is for a file name, so it uses a different time format
+    ts = datetime.utcfromtimestamp(int(time.time())).strftime("%Y-%m-%d-%H:%M:%S")
+    fileHandler = logging.FileHandler(os.path.join(log_folder, f"{name}.log.{ts}.yaml"))
+
+    fileHandler.setFormatter(formatter)
+    fileHandler.setLevel(logging.DEBUG)
+
+    logger.addHandler(fileHandler)
+
+
+configure_logger()

--- a/kombuworker/queuetools.py
+++ b/kombuworker/queuetools.py
@@ -16,6 +16,7 @@ import tenacity
 from kombu import Connection
 from kombu.simple import SimpleQueue
 
+from kombuworker.log import logger as kwlogger
 
 # Defining retry behavior for submit_task (a few lines down)
 retry = tenacity.retry(
@@ -83,7 +84,7 @@ def fetch_msgs(
             msg = rec_threadq.get_nowait()
 
             if verbose:
-                print(f"message received: {msg}")
+                kwlogger.info(f"message received: {msg}")
             waiting_period = init_waiting_period
             num_tries = 0
 
@@ -94,11 +95,11 @@ def fetch_msgs(
                 num_in_queue = queue.qsize()
                 if num_in_queue == 0:
                     if verbose:
-                        print("queue empty")
+                        kwlogger.info("queue empty")
                     raise Exception("queue empty")  # increment num_tries
                 else:
                     if verbose:
-                        print(
+                        kwlogger.info(
                             f"{num_in_queue} messages remain in the queue,"
                             f" sleeping for {waiting_period}s"
                         )
@@ -211,7 +212,7 @@ def fetch_msg(
     msg = queue.get_nowait()
 
     if verbose:
-        print_msg_received(msg)
+        kwlogger.info(msg)
 
     if rec_threadq is not None:
         rec_threadq.put(msg)
@@ -221,7 +222,7 @@ def fetch_msg(
 
 def print_msg_received(message: kombu.Message) -> None:
     """Prints a simple 'message received' statement with the payload."""
-    print(f"Fetched a message from the queue: {message.payload}")
+    kwlogger.info(f"Fetched a message from the queue: {message.payload}")
 
 
 def ack_msg(

--- a/kombuworker/taskqueueworker.py
+++ b/kombuworker/taskqueueworker.py
@@ -12,6 +12,8 @@ from taskqueue.queueables import totask, FunctionTask, RegisteredTask
 
 from . import queuetools as qt
 
+from kombuworker.log import logger as kwlogger
+
 
 def insert_tasks(queue_url: str, queue_name: str, tasks: Iterable):
     """Inserts tasks into a queue."""
@@ -62,11 +64,10 @@ def poll(
     def sigint_handler(signum, frame):
         global KEEP_LOOPING
         if KEEP_LOOPING:
-            print(
+            kwlogger.info(
                 "Interrupted."
                 " Exiting after this task completes."
                 " Interrupt again to exit now.",
-                flush=True,
             )
             KEEP_LOOPING = False
         else:
@@ -93,7 +94,7 @@ def poll(
             elapsed = time.time() - start_time
 
             qt.ack_msg(msg)
-            print(f"Task successfully executed in {elapsed:.2f}s")
+            kwlogger.info(f"Task successfully executed in {elapsed:.2f}s")
 
         except StopIteration:
             break

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(
     author_email="nturner@zetta.ai",
     url="https://github.com/ZettaAI/kombu-worker",
     packages=setuptools.find_packages(),
-    install_requires=["kombu", "tenacity", "requests"],
+    install_requires=["kombu", "tenacity", "requests", "task-queue"],
 )


### PR DESCRIPTION
The major change here is to use logging module instead of using `print`. 
What previously would reported as 
```
10 messages remain in the queue, sleeping for 0.1s  
Task successfully executed in 0.00s 
```
now logs as 
```
 [05-19 17:25:34.984, pid  1694,        queuetools.py: 102]   INFO - 10 messages remain in the queue, sleeping for 0.1s  
 [05-19 17:25:35.086, pid  1694,          agnostic.py: 125]   INFO - Task successfully executed in 0.00s 
```

Moreover, each run will now create a log file in the specified folder (default=`/tmp/logs/kombuworker/`), duplicating all of the stdout outputs.

There's also two minor fixes:
1. Include `task-queue` as a dependency in `setup.py`
2.  `list[dict]` -> `List[dict]` 