### PR TITLE
Logging instead of Printing 

### DIFF
--- a/kombuworker/agnostic.py
+++ b/kombuworker/agnostic.py
@@ -1,4 +1,6 @@
 """Task interface where user packages define how to parse tasks."""
+from __future__ import annotations
+
 import sys
 import json
 import time
@@ -7,6 +9,7 @@ from types import SimpleNamespace
 from typing import Optional, Callable
 
 from . import queuetools as qt
+from .log import logger
 
 
 def parse_queue(
@@ -77,18 +80,17 @@ def poll(
     def siginthandler(signum, frame):
         global KEEP_LOOPING
         if KEEP_LOOPING:
-            print(
+            logger.info(
                 "Interrupted w/ SIGINT."
                 " Exiting after this task completes."
                 " Interrupt again to exit now.",
-                flush=True,
             )
             KEEP_LOOPING = False
         else:
             sys.exit()
 
     def sigtermhandler(signum, frame):
-        print("Interrupted w/ SIGTERM. Exiting now.", flush=True)
+        logger.info("Interrupted w/ SIGTERM. Exiting now.")
         sys.exit()
 
     prev_siginthandler = signal.getsignal(signal.SIGINT)
@@ -119,7 +121,7 @@ def poll(
             elapsed = time.time() - start_time
 
             qt.ack_msg(msg)
-            print(f"Task successfully executed in {elapsed:.2f}s")
+            logger.info(f"Task successfully executed in {elapsed:.2f}s")
 
         except StopIteration:
             break

--- a/kombuworker/log.py
+++ b/kombuworker/log.py
@@ -1,0 +1,44 @@
+import logging
+import time
+import os
+import pathlib
+from datetime import datetime
+from typing import Optional, Callable
+
+
+logger = logging.getLogger("kombuworker")
+
+
+def configure_logger(
+    name: Optional[str] = "kombuworker",
+    verbose: Optional[bool] = True,
+    log_folder: Optional[str] = "/tmp/logs/kombuworker",
+):
+    global logger
+
+    pathlib.Path(log_folder).mkdir(parents=True, exist_ok=True)
+
+    # clear to avoid double add
+    logger.handlers = []
+    log_level = logging.DEBUG if verbose else logging.INFO
+    logger.setLevel(log_level)
+
+    ch = logging.StreamHandler()
+    ch.setLevel(log_level)
+    info_format = "[%(asctime)s.%(msecs)03d, pid%(process)6s, %(filename)20s:%(lineno)4d] %(levelname)6s - %(message)s"
+    time_format = "%m-%d %H:%M:%S"
+    formatter = logging.Formatter(info_format, time_format)
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+    # This ts is for a file name, so it uses a different time format
+    ts = datetime.utcfromtimestamp(int(time.time())).strftime("%Y-%m-%d-%H:%M:%S")
+    fileHandler = logging.FileHandler(os.path.join(log_folder, f"{name}.log.{ts}.yaml"))
+
+    fileHandler.setFormatter(formatter)
+    fileHandler.setLevel(logging.DEBUG)
+
+    logger.addHandler(fileHandler)
+
+
+configure_logger()

--- a/kombuworker/queuetools.py
+++ b/kombuworker/queuetools.py
@@ -16,6 +16,8 @@ import tenacity
 from kombu import Connection
 from kombu.simple import SimpleQueue
 
+from .log import logger
+
 
 # Defining retry behavior for submit_task (a few lines down)
 retry = tenacity.retry(
@@ -83,7 +85,7 @@ def fetch_msgs(
             msg = rec_threadq.get_nowait()
 
             if verbose:
-                print(f"message received: {msg}")
+                logger.info(f"message received: {msg}")
             waiting_period = init_waiting_period
             num_tries = 0
 
@@ -94,11 +96,11 @@ def fetch_msgs(
                 num_in_queue = queue.qsize()
                 if num_in_queue == 0:
                     if verbose:
-                        print("queue empty")
+                        logger.info("queue empty")
                     raise Exception("queue empty")  # increment num_tries
                 else:
                     if verbose:
-                        print(
+                        logger.info(
                             f"{num_in_queue} messages remain in the queue,"
                             f" sleeping for {waiting_period}s"
                         )
@@ -221,7 +223,7 @@ def fetch_msg(
 
 def print_msg_received(message: kombu.Message) -> None:
     """Prints a simple 'message received' statement with the payload."""
-    print(f"Fetched a message from the queue: {message.payload}")
+    logger.info(f"Fetched a message from the queue: {message.payload}")
 
 
 def ack_msg(

--- a/kombuworker/taskqueueworker.py
+++ b/kombuworker/taskqueueworker.py
@@ -12,6 +12,8 @@ from taskqueue.queueables import totask, FunctionTask, RegisteredTask
 
 from . import queuetools as qt
 
+from .log import logger
+
 
 def insert_tasks(queue_url: str, queue_name: str, tasks: Iterable):
     """Inserts tasks into a queue."""
@@ -62,11 +64,10 @@ def poll(
     def sigint_handler(signum, frame):
         global KEEP_LOOPING
         if KEEP_LOOPING:
-            print(
+            logger.info(
                 "Interrupted."
                 " Exiting after this task completes."
                 " Interrupt again to exit now.",
-                flush=True,
             )
             KEEP_LOOPING = False
         else:
@@ -93,7 +94,7 @@ def poll(
             elapsed = time.time() - start_time
 
             qt.ack_msg(msg)
-            print(f"Task successfully executed in {elapsed:.2f}s")
+            logger.info(f"Task successfully executed in {elapsed:.2f}s")
 
         except StopIteration:
             break


### PR DESCRIPTION
Use logging module instead of using print.
What previously would reported as:
```
10 messages remain in the queue, sleeping for 0.1s  
Task successfully executed in 0.00s 
```
now logs as:
```
 [05-19 17:25:34.984, pid  1694,        queuetools.py: 102]   INFO - 10 messages remain in the queue, sleeping for 0.1s  
 [05-19 17:25:35.086, pid  1694,          agnostic.py: 125]   INFO - Task successfully executed in 0.00s 
```

Moreover, each run will now create a log file in the specified folder (default=/tmp/logs/kombuworker/), duplicating all of the stdout outputs.

Formatted with `black==19.10b0` 