### PR TITLE
[test] requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,10 @@ setup(
     url="https://github.com/ZettaAI/kombu-worker",
     packages=setuptools.find_packages(),
     install_requires=["kombu", "tenacity", "requests"],
+    extras_require={
+        "test": [
+            "pytest",  # potentiall would be good to pin the verision
+            "task-queue",
+        ]
+    },
 )


### PR DESCRIPTION
@nicholasturner1 Would installing dependency options through `extras_require` agree with your vision of multiple front-ends?

I've researched a little bit on the different installation methods for packages. It's some interesting stuff, although it seems like the difference between methods is purely esthetic and matters only in complicated projects. It does seem like `setup.cfg`/`pyproject.toml` are now preferred to `setup.py` [[link](https://stackoverflow.com/a/60885212)]. The advantage of `pyproject.toml` is that it can support different build systems and versions, works better with python-poetry etc. Unfortunately one can't get away with only `pyproject.toml` without `setup.cfg` yet, as not all distribution tools support that yet. At least I tried and failed to make it work with `setuptools`. In my new repo I use `pyproject.toml` for linting and testing parameter specifications [[link]](https://github.com/ZettaAI/zetta_utils/blob/main/pyproject.toml).