### PR TITLE
fix: monitor NotVisible messages + Visible

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -30,6 +30,34 @@ def rabbitMQurl():
 
     yield "amqp://localhost:5672"
 
+    kill_subprocess(p)
+
+
+@pytest.fixture(scope="session")
+def SQSurl():
+    """Starts an ElasticMQ docker container and tears it down."""
+    p = subprocess.Popen(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--name",
+            "elasticmq",
+            "-p",
+            "9324:9324",
+            "-p",
+            "9325:9325",
+            "softwaremill/elasticmq-native",
+        ]
+    )
+    time.sleep(0.5)
+
+    yield "sqs://localhost:9324"
+
+    kill_subprocess(p)
+
+
+def kill_subprocess(p: subprocess.Popen) -> None:
     # Being a bit obsessive here
     retries = 10
     while retries > 0:

--- a/test/utils.py
+++ b/test/utils.py
@@ -8,7 +8,7 @@ from kombuworker import queuetools as qt
 
 
 def count_msgs(queue_url: str, queue_name: str) -> int:
-    """Counts the number of remaining messages in a queue.
+    """Counts the number of remaining (visible) messages in a queue.
 
     Also empties the queue.
     """


### PR DESCRIPTION
SimpleQueue.qsize() just keeps track of visible messages. It's important
to keep track of unacked messages as well to keep workers from dying
before the work is finished.